### PR TITLE
Empty string when change the Proxy address

### DIFF
--- a/src/kcms/kio/kproxydlg.cpp
+++ b/src/kcms/kio/kproxydlg.cpp
@@ -206,7 +206,11 @@ static void setProxyInformation(const QString& value,
             manEdit->setText(((KSaveIOConfig::proxyDisplayUrlFlags() & flag) ? url.host(): url.url()));
         } else {
             QUrl url(urlStr);
-            manEdit->setText((KSaveIOConfig::proxyDisplayUrlFlags() & flag) ? url.host() : urlStr);
+            if (KSaveIOConfig::proxyDisplayUrlFlags() & flag) {
+                manEdit->setText((url.scheme().isEmpty()) ? url.path() : url.host());
+            } else {
+                manEdit->setText(urlStr);
+            }
         }
 
         if (spinBox && portNum > -1) {


### PR DESCRIPTION
The url of the field "Proxy SOCKS:" is not restored to the QLineEdit when the Proxy program is reopened.
The problem is if the variable "Qurl url" doesn't have a scheme, host() returns a empty string. Hope this helps.