### PR TITLE
Clang+libcxx compiler error

### DIFF
--- a/src/ioslaves/file/file_unix.cpp
+++ b/src/ioslaves/file/file_unix.cpp
@@ -31,6 +31,7 @@
 #include <kmountpoint.h>
 
 #include <cerrno>
+#include <array>
 #include <stdint.h>
 #include <utime.h>
 


### PR DESCRIPTION
Missing <array> include