### PR TITLE
Add missing "truncating" parameter to protocoltojson

### DIFF
--- a/src/protocoltojson/main.cpp
+++ b/src/protocoltojson/main.cpp
@@ -78,6 +78,7 @@ int main(int argc, char *argv[])
                                       QStringLiteral("linking"),
                                       QStringLiteral("moving"),
                                       QStringLiteral("opening"),
+                                      QStringLiteral("truncating"),
                                       QStringLiteral("copyFromFile"),
                                       QStringLiteral("copyToFile"),
                                       QStringLiteral("renameFromFile"),


### PR DESCRIPTION
The protocoljson does not transfer the "truncating" parameter to the json file,
causing this bug https://bugs.kde.org/show_bug.cgi?id=450198